### PR TITLE
README:Minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cookie:
 
     doc = {
         'username':'Johnny',
-        'password': stauth.Hasher(['dog']).generate()[0]
+        'password': stauth.Hasher(['dog']).generate()[0],
         'email': 'johnwick@wicked.com',
         'name': 'John Wick'
     }


### PR DESCRIPTION
In the README file there was a minor typo (a missing comma) in the *Create a Mongodb document and insert to the database* section.